### PR TITLE
Update persistent volume settings

### DIFF
--- a/buildnDeploy/Dockerfile
+++ b/buildnDeploy/Dockerfile
@@ -13,35 +13,42 @@ WORKDIR /go/src/upspin/upspin
 # Build the binaries
 RUN GOOS=linux GOARCH=amd64 go build upspin.io/cmd/upspinserver
 
-# Build upspinserver-drive
-RUN go get drive.upspin.io/cmd/...
-
 # Start a new image base of ubuntu
 FROM ubuntu:latest
 
 # Just an example for how to install other packages in the docker file, could be deleted if not needed
 RUN apt-get update
-RUN apt-get install -y curl gettext libnss-wrapper
+RUN apt-get install -y gettext libnss-wrapper
 
 # Add user named upspin
 RUN useradd -m upspin
 
 # Create the /upspin directory in Dockerfile manually for now
-RUN mkdir -p /upspin
-RUN chgrp -R 0 /upspin && chmod -R g+rwX /upspin
+# RUN mkdir -p /upspin
+# RUN chgrp -R 0 /upspin && chmod -R g+rwX /upspin
+
 
 # Work directory will be in format /home/{$USER}
 WORKDIR /home/upspin
+
+# Set the vaule of environment variable HOME as /home/upspin in this container
+ENV HOME=/home/upspin
+
 
 # Copy the upspinserver binary from previous build to current image
 COPY --from=build /go/src/upspin/upspin/upspinserver .
 
 # This directiory is needed for HTTPS connections
 RUN mkdir -p upspin/letsencrypt
+RUN mkdir -p upspin/server
+RUN mkdir -p upspin/server/storage
 
 # Refer to Support Arbitrary User IDs section in 
 # https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines
-RUN chgrp -R 0 upspin/letsencrypt && chmod -R g+rwX upspin/letsencrypt
+# RUN chgrp -R 0 upspin/letsencrypt && chmod -R g+rwX upspin/letsencrypt
+
+# Set the ownership of upspin directory as root group, and add r,w,x permission to the root group
+RUN chgrp -R 0 upspin && chmod -R g+rwX upspin
 
 # Add the local file into Docker image
 ADD passwd.template .
@@ -51,12 +58,17 @@ RUN chmod +x ./start.sh
 EXPOSE 6443 8080
 
 # Run upspinserver as user upspin we just created
-USER upspin:upspin
+USER upspin
+
+# Mount
+VOLUME "/home/upspin/upspin/"
+
 
 # Currently the pod could not handle the external https request correctly. See the details in the log of pod.
 # CMD ./upspinserver -https=:6443 -http=:8080
 
 # The pod could handle the external http request correctly with the insecure flag though
 # CMD ./upspinserver -insecure=true -https=:6443 -http=:8080
+
 
 CMD ./start.sh

--- a/buildnDeploy/start.sh
+++ b/buildnDeploy/start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 export USER_ID=$(id -u)
 export GROUP_ID=$(id -g)
-envsubst < /home/upspin/passwd.template > /tmp/passwd
+envsubst < ${HOME}/passwd.template > /tmp/passwd
 export LD_PRELOAD=/usr/lib/libnss_wrapper.so
 export NSS_WRAPPER_PASSWD=/tmp/passwd
 export NSS_WRAPPER_GROUP=/etc/group

--- a/buildnDeploy/template.yaml
+++ b/buildnDeploy/template.yaml
@@ -29,7 +29,7 @@
 kind: Template
 apiVersion: v1
 metadata:
-  name: jp-template-storage
+  name: jp-template-volume
 
 # Image stream object
 objects:
@@ -183,27 +183,27 @@ objects:
 # Change these parameters according to your needs
 parameters:
 - name: DEPLOYMENT_NAME
-  value: upspin-jp-storage
+  value: upspin-jp-volume
   required: true
 
 - name: IMAGE
-  value: upspinio/upspin:upspin-jp-storage
+  value: upspinio/upspin:upspin-jp-volume11
   required: true
 
 # Dockerhub image tag
 - name: IMAGE_TAG
-  value: upspin-jp-storage
+  value: upspin-jp-volume11
 
 - name: ROUTE_NAME
-  value: upspin-jp-storage-cname
+  value: upspin-jp-volume-cname
   required: true
 
 - name: HOST_NAME
-  value: jp-storage-1.mocupspin.com
+  value: jp-vo.mocupspin.com
   required: true
 
 - name: OPENSHIFT_HOST_NAME
-  value: upspin-jp-storage-cs6620-sp2021-universal-namespace.k-apps.osh.massopen.cloud
+  value: upspin-jp-volume-cs6620-sp2021-universal-namespace.k-apps.osh.massopen.cloud
   required: true
 
 - name: SOURCE_SSL_PORT
@@ -214,13 +214,16 @@ parameters:
   value: "80"
   required: true
 
-# Created PVC with 10GB on OpenShift storage
-# Don't need to change the value of "upspin-storage-rwo"
+# Created PVC with 10GB, type as RWO, on OpenShift storage
+# Currently don't need to change the value of "upspin-storage-rwo"
 - name: PVC_NAME
   value: upspin-storage-rwo
+  required: true
 
 - name: MOUNT_PATH
-  value: /data
+  value: /home/upspin/upspin/
+  required: true
 
 - name: VOLUME_NAME
-  value: upspin-jp-storage-path
+  value: upspin-jp-volume-path
+  required: true


### PR DESCRIPTION
Update settings of persistent volume claim and mounting path in YAML template and DockerFile.
Update allow for persisting server configs and storage, when scaling up&down the deployment and deleting&auto-generating the pod.